### PR TITLE
createReleaseAndUploadBins: Create draft release, not public

### DIFF
--- a/createReleaseAndUploadBins/index.js
+++ b/createReleaseAndUploadBins/index.js
@@ -50,7 +50,7 @@ wrapper({
       name: opts.version,
       notes: opts.notes,
       tag: opts.version,
-      draft: false,
+      draft: true,
       prerelease: false,
       editRelease: true,
       reuseRelease: true,


### PR DESCRIPTION
Allows us to inspect the draft and update release notes before publishing.

NOTE: It may end up being pointless to tweak this option of `publish-release` if we do eventually switch to using `gh` CLI instead of `publish-release` package. But I'm posting this PR anyway while I have free time to do so. 👍 As discussed briefly on Discord.