### PR TITLE
downloadBinsWhenPossible: Get macos-13 bins, not macos-12 bins

### DIFF
--- a/downloadBinsWhenPossible/index.js
+++ b/downloadBinsWhenPossible/index.js
@@ -30,7 +30,7 @@ const DEFAULTS = {
   githubActionName: "Build Pulsar Binaries", // The workflow name who will have
   // the built binaries as artifacts in GitHub
   githubArtifactsToDownload: [
-    "macos-12 Binaries",
+    "macos-13 Binaries",
     "ubuntu-latest Binaries",
     "windows-latest Binaries"
   ], // ^^ Names of the Artifacts we want to download from GitHub


### PR DESCRIPTION
Core Pulsar repo is building on macOS 13 CI runners now.

Ensure we get all the bins. Without this change, we skip downloading the macOS bins, as the "macos-12 Binaries" string doesn't match "macos-13 Binaries".

---

Might be more graceful solutions to this, but we can hotfix it this way for now. (???)

Solutions might include making it so the names of the "Binaries" CI assets we upload on a given GitHub Actions run are not dependent on the runner OS's exact version spec. (For example: from "macos-13 Binaries" to --> just "macos Binaries"???) And/or making the string comparison more flexible in `downloadBinsWhenPossible/getGitHubBins.js`, more wildcard or substring match than exact match.